### PR TITLE
fix/add linters

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -1,0 +1,24 @@
+name: golangci-lint
+on:
+  push:
+    tags:
+      - v*
+    branches:
+      - master
+  pull_request:
+permissions:
+  contents: read
+jobs:
+  golangci:
+    name: lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-go@v4
+        with:
+          go-version: '1.20'
+          cache: false
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v3
+        with:
+          version: latest

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,0 +1,14 @@
+linters:
+  enable:
+    - gosec
+    - govet
+  presets:
+    - bugs
+    - performance
+run:
+  go: '1.20'
+issues:
+  exclude-rules:
+    - path: testing
+      linters:
+        - errcheck

--- a/keys.go
+++ b/keys.go
@@ -17,7 +17,7 @@ func (c *Cache) Keys() []string {
 // Returns:
 //   - A slice of strings containing all the keys in the cache.
 func (c *Cache) keys() []string {
-	var keys []string = []string{}
+	keys := make([]string, 0, len(c.data))
 	for key := range c.data {
 		keys = append(keys, key)
 	}

--- a/nocache/search.go
+++ b/nocache/search.go
@@ -67,7 +67,7 @@ func (ft *FullText) search(sp SearchParams) []map[string]any {
 
 	// Variables for storing the smallest words array
 	var (
-		smallest      int = 0
+		smallest      int = 0 //nolint:ineffassign
 		smallestIndex int = 0
 	)
 

--- a/search.go
+++ b/search.go
@@ -65,7 +65,7 @@ func (c *Cache) search(sp SearchParams) []map[string]any {
 
 	// Variables for storing the smallest words array
 	var (
-		smallest      int = 0
+		smallest      int = 0 //nolint:ineffassign
 		smallestIndex int = 0
 	)
 

--- a/values.go
+++ b/values.go
@@ -17,7 +17,7 @@ func (c *Cache) Values() []map[string]any {
 // Returns:
 //   - A slice of map[string]any representing all the values in the cache.
 func (c *Cache) values() []map[string]any {
-	var values []map[string]any = []map[string]any{}
+	values := make([]map[string]any, 0, len(c.data))
 	for _, value := range c.data {
 		values = append(values, value)
 	}


### PR DESCRIPTION
Fixes #2 

Adds the gosec and govet linters, to help ensure that the package isn't inadvertently introducing vulnerabilites to the consuming software.

I also took the liberty of adding the `performance` and `bugs` presets, since this package prides itself on being fast. The `prealloc` linter highlighted two slice assignments that could benefit from length preallocation, as their final size is known ahead of time. 

On a general basis, I'd advise turning on the `gofumpt` linter as well, so that you can easily enforce code-style going forward. However, running it produces a large diff right now, so that should rather be its own separate PR, if and when the need arises.

Looking forward to following the development of this project :)